### PR TITLE
updates from feedback

### DIFF
--- a/src/Commands/Add.hs
+++ b/src/Commands/Add.hs
@@ -5,8 +5,7 @@ module Commands.Add
 
 import           Data.List        (lines, unlines)
 import           Entry
-import           Helpers          (getFilePath, indentedOutput, loadEntries,
-                                   nextRowNum, parseEntries, showOutput)
+import           Helpers          (getFilePath, indentedOutput, loadLines)
 import           System.Directory (removeFile, renameFile)
 import           System.IO        (readFile)
 
@@ -18,9 +17,8 @@ add ["--help"]      = putStrLn "usage: timetrack add YYYY-MM-DD \"message\""
 add [_]             = putStrLn "Not enough arguments provided.\nFor help: timetrack add --help"
 add [date, message] = do
     path <- getFilePath
-    loadedLines <- loadEntries
-    let entries = parseEntries loadedLines
-        index = nextRowNum entries
+    entries <- fmap parseLines loadLines
+    let index = nextRowNum entries
         newEntry = Entry { index = index, date = date, message = message }
         updatedEntries = entries ++ [newEntry]
         tmpPath = path ++ ".tmp"

--- a/src/Commands/Help.hs
+++ b/src/Commands/Help.hs
@@ -10,6 +10,6 @@ cmds =
         "  ls   List entries"
 
 
-help :: a -> IO ()
-help _ =
+help :: IO ()
+help =
     putStrLn cmds

--- a/src/Commands/List.hs
+++ b/src/Commands/List.hs
@@ -3,12 +3,13 @@ module Commands.List
     ) where
 
 
-import           Helpers (loadEntries, parseEntries, printEntries)
+import           Entry   (parseLines, printEntries)
+import           Helpers (loadLines)
 
 
 ls :: [String] -> IO ()
 ls _ = do
-    loadedLines <- loadEntries
+    loadedLines <- loadLines
     putStrLn "#  Date        Description"
     putStrLn "-  ----------  -----------"
-    printEntries $ parseEntries loadedLines
+    printEntries $ parseLines loadedLines

--- a/src/Commands/NotFound.hs
+++ b/src/Commands/NotFound.hs
@@ -6,7 +6,7 @@ module Commands.NotFound
 import           Commands.Help (help)
 
 
-notFound :: String -> a -> IO ()
-notFound cmd _ = do
+notFound :: String -> IO ()
+notFound cmd = do
     putStrLn $ "No such command: " ++ cmd
-    help Nothing
+    help

--- a/src/Entry.hs
+++ b/src/Entry.hs
@@ -1,6 +1,18 @@
 module Entry
-    ( Entry(..)
+    ( Entry ( Entry
+            , date
+            , index
+            , message
+            )
+    , nextRowNum
+    , parseLines
+    , printEntries
+    , showOutput
     ) where
+
+
+import           Helpers   (inc)
+import           System.IO (readFile)
 
 
 data Entry = Entry
@@ -13,3 +25,32 @@ data Entry = Entry
 instance Show Entry where
     show (Entry index entry message) =
         show index ++ "  " ++ entry ++ "  " ++ message
+
+
+nextRowNum :: [Entry] -> Integer
+nextRowNum =
+    inc . fromIntegral . length
+
+
+parse :: Integer -> String -> Entry
+parse n line =
+    let
+        (date, rest) = splitAt 10 line
+        message = drop 1 rest
+    in
+        Entry { index = n, date = date, message = message }
+
+
+parseLines :: [String] -> [Entry]
+parseLines =
+    zipWith parse [1..]
+
+
+printEntries :: [Entry] -> IO ()
+printEntries =
+    putStrLn . unlines . fmap show
+
+
+showOutput :: Entry -> String
+showOutput entry =
+    date entry ++ " " ++ message entry

--- a/src/Helpers.hs
+++ b/src/Helpers.hs
@@ -2,25 +2,25 @@ module Helpers
     ( getFilePath
     , inc
     , indentedOutput
-    , loadEntries
-    , nextRowNum
-    , parseEntries
-    , parseEntry
-    , printEntries
-    , showOutput
+    , loadLines
     ) where
 
 
 import           Data.List        (lines, unlines)
-import           Entry
 import           System.Directory (getAppUserDataDirectory)
-import           System.IO        (readFile)
 
 
 getFilePath :: IO FilePath
 getFilePath = do
     path <- getAppUserDataDirectory "timetrack"
     return $ path ++ "/timetrack.txt"
+
+
+loadLines :: IO [String]
+loadLines = do
+    path <- getFilePath
+    contents <- readFile path
+    return $ lines contents
 
 
 inc :: Integer -> Integer
@@ -31,39 +31,3 @@ inc =
 indentedOutput :: String -> String
 indentedOutput str =
     "   ├── " ++ str
-
-
-nextRowNum :: [Entry] -> Integer
-nextRowNum =
-    inc . fromIntegral . length
-
-
-loadEntries :: IO [String]
-loadEntries = do
-    path <- getFilePath
-    contents <- readFile path
-    return $ lines contents
-
-
-parseEntries :: [String] -> [Entry]
-parseEntries =
-    zipWith parseEntry [1..]
-
-
-parseEntry :: Integer -> String -> Entry
-parseEntry n line =
-    let
-        (date, rest) = splitAt 10 line
-        message = drop 1 rest
-    in
-        Entry { index = n, date = date, message = message }
-
-
-printEntries :: [Entry] -> IO ()
-printEntries =
-    putStrLn . unlines . fmap show
-
-
-showOutput :: Entry -> String
-showOutput entry =
-    date entry ++ " " ++ message entry

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -19,6 +19,10 @@ dispatch "--help" = help
 dispatch cmd      = notFound cmd
 
 
-timeTrack = do
-    (cmd:argList) <- getArgs
-    dispatch cmd argList
+parse :: [String] -> IO ()
+parse (cmd:argList) = dispatch cmd argList
+parse _             = help Nothing
+
+
+timeTrack =
+    getArgs >>= parse

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -14,14 +14,14 @@ dispatch :: String -> [String] -> IO ()
 dispatch "add"    = add
 dispatch "list"   = ls
 dispatch "ls"     = ls
-dispatch "-h"     = help
-dispatch "--help" = help
-dispatch cmd      = notFound cmd
+dispatch "-h"     = const help
+dispatch "--help" = const help
+dispatch cmd      = const $ notFound cmd
 
 
 parse :: [String] -> IO ()
 parse (cmd:argList) = dispatch cmd argList
-parse _             = help Nothing
+parse _             = help
 
 
 timeTrack =


### PR DESCRIPTION
These are updates made after reviewing feedback from @jamesdabbs on https://github.com/rpearce/timetrack-cli/pull/6.

* running `$ timetrack` by itself will now not throw an error but will print some help text
* I moved anything having to do with `Entry` to the `Entry.hs` module and kept generic/unclassified helpers in the `Helpers.hs` module
* refactored to use `fmap` for getting entries based on this conversation: https://github.com/rpearce/timetrack-cli/pull/6/files#r183184562
* updated `help` and `notFound` function calling to use [`const`](https://hackage.haskell.org/package/base-4.11.1.0/docs/Prelude.html#v:const) in order to change it's signature from `a -> IO ()` to just `IO ()`

cc @goodforenergy (if you got time!)