### PR TITLE
fn and output updates

### DIFF
--- a/src/Commands/List.hs
+++ b/src/Commands/List.hs
@@ -8,8 +8,5 @@ import           Helpers (loadLines)
 
 
 ls :: [String] -> IO ()
-ls _ = do
-    loadedLines <- loadLines
-    putStrLn "#  Date        Description"
-    putStrLn "-  ----------  -----------"
-    printEntries $ parseLines loadedLines
+ls _ =
+    fmap parseLines loadLines >>= printEntries

--- a/src/Entry.hs
+++ b/src/Entry.hs
@@ -24,7 +24,13 @@ data Entry = Entry
 
 showEntry :: Entry -> String
 showEntry (Entry index date message) =
-    show index ++ "  " ++ date ++ "  " ++ message
+    prettyIndex index ++ "  " ++ date ++ "  " ++ message
+
+
+prettyIndex :: Integer -> String
+prettyIndex n
+    | n < 10    = "0" ++ show n
+    | otherwise = show n
 
 
 nextRowNum :: [Entry] -> Integer

--- a/src/Helpers.hs
+++ b/src/Helpers.hs
@@ -10,18 +10,15 @@ import           System.Directory (getAppUserDataDirectory)
 
 
 getFilePath :: IO FilePath
-getFilePath = do
-    path <- getAppUserDataDirectory "timetrack"
-    return $ path ++ "/timetrack.txt"
+getFilePath =
+    fmap (++ "/timetrack.txt") (getAppUserDataDirectory "timetrack")
 
 
 loadLines :: IO [String]
-loadLines = do
-    path <- getFilePath
-    contents <- readFile path
-    return $ lines contents
+loadLines =
+    fmap lines (getFilePath >>= readFile)
 
 
 indentedOutput :: String -> String
-indentedOutput str =
-    "   ├── " ++ str
+indentedOutput =
+    (++) "   ├── "


### PR DESCRIPTION
Couple of things mixed in here:
* refactors some `do` expressions to use `bind` and `fmap`
* removing header print output so that the tool can be composed and used with other unix-style commands easily
* left-pads line numbers 1-9 with a `0`